### PR TITLE
Update spec to shift ES2017

### DIFF
--- a/src/term-spec.js
+++ b/src/term-spec.js
@@ -35,6 +35,10 @@ declare export class MethodDefinition extends NamedObjectProperty {
   body: FunctionBody;
 }
 
+declare export class VariableReference extends Term {
+  name: any; // Identifier (string)
+}
+
 /* ***** Bindings ***** */
 
 // type Binding = (ObjectBinding | ArrayBinding | BindingIdentifier | MemberExpression);
@@ -44,8 +48,20 @@ declare export class BindingWithDefault extends Term {
   init: Expression;
 }
 
-declare export class BindingIdentifier extends Term {
-  name: any;
+declare export class BindingIdentifier extends VariableReference { }
+
+declare export class AssignmentTargetIdentifier extends VariableReference { }
+
+declare export class MemberAssignmentTarget extends Term { 
+  object: Expression | Super;
+}
+
+declare export class ComputedMemberAssignmentTarget extends MemberAssignmentTarget { 
+  expression: Expression;
+}
+
+declare export class StaticMemberAssignmentTarget extends MemberAssignmentTarget { 
+  property: any;
 }
 
 declare export class ArrayBinding extends Term {
@@ -71,6 +87,43 @@ declare export class BindingPropertyProperty extends BindingProperty {
   // binding: Binding | BindingWithDefault;
   binding: ObjectBinding | ArrayBinding | BindingIdentifier | MemberExpression | BindingWithDefault;
 }
+
+/*
+  AssignmentTarget = 
+      ObjectAssignmentTarget 
+    | ArrayAssignmentTarget
+    | AssignmentTargetIdentifier
+    | MemberAssignmentTarget
+*/
+
+declare export class AssignmentTargetWithDefault extends Term {
+  binding: ObjectAssignmentTarget | ArrayAssignmentTarget | AssignmentTargetIdentifier | MemberAssignmentTarget;
+  init: Expression;
+}
+
+
+declare export class ArrayAssignmentTarget extends Term {
+  elements?: (ObjectAssignmentTarget | ArrayAssignmentTarget | AssignmentTargetIdentifier | MemberAssignmentTarget | AssignmentTargetWithDefault)[];
+  rest?: ObjectAssignmentTarget | ArrayAssignmentTarget | AssignmentTargetIdentifier | MemberAssignmentTarget;
+}
+
+declare export class ObjectAssignmentTarget extends Term {
+  properties?: AssignmentTargetProperty[];
+}
+
+declare export class AssignmentTargetProperty extends Term { }
+
+declare export class AssignmentTargetPropertyIdentifier extends AssignmentTargetProperty { 
+  binding: AssignmentTargetIdentifier;
+  init?: Expression;
+}
+
+declare export class AssignmentTargetPropertyProperty extends AssignmentTargetProperty { 
+  name: PropertyName;
+  init?: Expression;
+}
+
+
 
 // class
 declare export class ClassExpression extends Expression {
@@ -226,7 +279,7 @@ declare export class ArrowExpressionE extends Expression {
 
 declare export class AssignmentExpression extends Expression {
   // binding: Binding;
-  binding: BindingIdentifier | BindingPropertyProperty | BindingPropertyIdentifier | ObjectBinding | ArrayBinding | MemberExpression;
+  binding: ObjectAssignmentTarget | ArrayAssignmentTarget | AssignmentTargetIdentifier | MemberAssignmentTarget;
   expression: Expression;
 }
 
@@ -247,7 +300,7 @@ declare export class CallExpressionE extends Expression {
 }
 
 declare export class CompoundAssignmentExpression extends Expression {
-  binding: BindingIdentifier | MemberExpression;
+  binding: AssignmentTargetIdentifier | MemberAssignmentTarget;
   operator: any;
   expression: Expression;
 }
@@ -312,7 +365,7 @@ declare export class ThisExpression extends Expression {
 declare export class UpdateExpression extends Expression {
   isPrefix: any;
   operator: any;
-  operand: BindingIdentifier | MemberExpression;
+  operand: AssignmentTargetIdentifier | MemberAssignmentTarget;
 }
 
 declare export class YieldExpression extends Expression {
@@ -362,7 +415,7 @@ declare export class ForInStatement extends IterationStatement {
 }
 
 declare export class ForOfStatement extends IterationStatement {
-  left: VariableDeclaration | ObjectBinding | ArrayBinding | BindingIdentifier | MemberExpression;
+  left: VariableDeclaration | ObjectAssignmentTarget | ArrayAssignmentTarget | AssignmentTargetIdentifier | MemberAssignmentTarget;
   right: Expression;
 }
 

--- a/src/term-spec.js
+++ b/src/term-spec.js
@@ -170,7 +170,7 @@ declare export class DataProperty extends NamedObjectProperty {
 }
 
 declare export class ShorthandProperty extends ObjectProperty {
-  name: any;
+  name: IdentifierExpression;
 }
 
 declare export class StaticPropertyName extends PropertyName {

--- a/src/term-spec.js
+++ b/src/term-spec.js
@@ -103,7 +103,7 @@ declare export class AssignmentTargetWithDefault extends Term {
 
 
 declare export class ArrayAssignmentTarget extends Term {
-  elements?: (ObjectAssignmentTarget | ArrayAssignmentTarget | AssignmentTargetIdentifier | MemberAssignmentTarget | AssignmentTargetWithDefault)[];
+  elements: (ObjectAssignmentTarget | ArrayAssignmentTarget | AssignmentTargetIdentifier | MemberAssignmentTarget | AssignmentTargetWithDefault | null)[];
   rest?: ObjectAssignmentTarget | ArrayAssignmentTarget | AssignmentTargetIdentifier | MemberAssignmentTarget;
 }
 
@@ -120,7 +120,7 @@ declare export class AssignmentTargetPropertyIdentifier extends AssignmentTarget
 
 declare export class AssignmentTargetPropertyProperty extends AssignmentTargetProperty { 
   name: PropertyName;
-  init?: Expression;
+  binding?: ObjectAssignmentTarget | ArrayAssignmentTarget | AssignmentTargetIdentifier | MemberAssignmentTarget | AssignmentTargetWithDefault;
 }
 
 

--- a/src/term-spec.js
+++ b/src/term-spec.js
@@ -52,7 +52,7 @@ declare export class ArrayBinding extends Term {
   // elements: (Binding | BindingWithDefault)[];
   elements: (ObjectBinding | ArrayBinding | BindingIdentifier | MemberExpression | BindingWithDefault | null)[];
   // restElement?: Binding
-  restElement?: ObjectBinding | ArrayBinding | BindingIdentifier | MemberExpression;
+  rest?: ObjectBinding | ArrayBinding | BindingIdentifier | MemberExpression;
 }
 
 declare export class ObjectBinding extends Term {

--- a/src/term-spec.js
+++ b/src/term-spec.js
@@ -195,7 +195,11 @@ declare export class LiteralNumericExpression extends Expression {
 
 declare export class LiteralRegExpExpression extends Expression {
   pattern: any;
-  flags: any;
+  global: any;
+  ignoreCase: any;
+  multiline: any;
+  sticky: any;
+  unicode: any;
 }
 
 declare export class LiteralStringExpression extends Expression {

--- a/src/term-spec.js
+++ b/src/term-spec.js
@@ -144,6 +144,7 @@ declare export class ExportSpecifier extends Term {
 
 // property definition
 declare export class Method extends MethodDefinition {
+  isAsync: any;
   isGenerator: any;
   params: FormalParameters;
 }
@@ -200,10 +201,12 @@ declare export class ArrayExpression extends Expression {
 }
 
 declare export class ArrowExpression extends Expression {
+  isAsync: any;
   params: FormalParameters;
   body: FunctionBody | Expression;
 }
 declare export class ArrowExpressionE extends Expression {
+  isAsync: any;
   params: FormalParameters;
   body: Term[];
 }
@@ -248,12 +251,14 @@ declare export class ConditionalExpression extends Expression {
 
 declare export class FunctionExpression extends Expression {
   name?: BindingIdentifier;
+  isAsync: any; // boolean
   isGenerator: any;
   params: FormalParameters;
   body: FunctionBody;
 }
 declare export class FunctionExpressionE extends Expression {
   name?: BindingIdentifier;
+  isAsync: any; // boolean
   isGenerator: any;
   params: FormalParameters;
   body: Term[];
@@ -302,6 +307,10 @@ declare export class YieldExpression extends Expression {
 }
 
 declare export class YieldGeneratorExpression extends Expression {
+  expression: Expression;
+}
+
+declare export class AwaitExpression extends Expression {
   expression: Expression;
 }
 
@@ -438,12 +447,14 @@ declare export class FunctionBody extends Term {
 
 declare export class FunctionDeclaration extends Statement {
   name: BindingIdentifier;
+  isAsync: any; // boolean
   isGenerator: any;
   params: FormalParameters;
   body: FunctionBody;
 }
 declare export class FunctionDeclarationE extends Statement {
   name: BindingIdentifier;
+  isAsync: any; // boolean
   isGenerator: any;
   params: FormalParameters;
   body: Term[];

--- a/src/term-spec.js
+++ b/src/term-spec.js
@@ -124,8 +124,12 @@ declare export class ExportAllFrom extends ExportDeclaration {
 }
 
 declare export class ExportFrom extends ExportDeclaration {
-  namedExports: ExportSpecifier[];
+  namedExports: ExportFromSpecifier[];
   moduleSpecifier?: any;
+}
+
+declare export class ExportLocals extends ExportDeclaration {
+  namedExports: ExportLocalSpecifier[];
 }
 
 declare export class Export extends ExportDeclaration {
@@ -136,9 +140,14 @@ declare export class ExportDefault extends ExportDeclaration {
   body: FunctionDeclaration | ClassDeclaration | Expression;
 }
 
-declare export class ExportSpecifier extends Term {
-  name?: any;
-  exportedName: any;
+declare export class ExportFromSpecifier extends Term {
+  name: any;
+  exportedName?: any;
+}
+
+declare export class ExportLocalSpecifier extends Term {
+  name: IdentifierExpression;
+  exportedName?: any;
 }
 
 


### PR DESCRIPTION
Sweet-spec was originally based of the ES6 version of shift spec so this updates includes all the changes from https://github.com/shapesecurity/shift-spec/compare/es6...es2017#diff-448c96409569a059a7e07cf28935a2c4