### PR TITLE
Add support for TypeScript type annotations

### DIFF
--- a/src/term-spec.js
+++ b/src/term-spec.js
@@ -36,7 +36,7 @@ declare export class MethodDefinition extends NamedObjectProperty {
   body: FunctionBody;
 }
 
-declare export class AbstractMethodDefinition extends Term {
+declare export class TsAbstractMethodDefinition extends Term {
   name: PropertyName;
   type?: TypeNode;
 }
@@ -142,54 +142,71 @@ declare export class AssignmentTargetPropertyProperty extends AssignmentTargetPr
 
 declare export class ClassExpression extends Expression {
   name?: BindingIdentifier;
-  typeParameters?: TypeParameterDeclaration[];
-  heritageClauses?: HeritageClause[];
-  elements: (ClassElement | IndexSignatureDeclaration)[];
+  super?: Expression;
+  elements: ClassElement[];
 }
 
 declare export class ClassDeclaration extends Statement {
-  isAbstract: any; // boolean
   name: BindingIdentifier;
-  typeParameters?: TypeParameterDeclaration[];
-  heritageClauses?: HeritageClause[];
-  elements: (ClassElement | IndexSignatureDeclaration)[];
+  super?: Expression;
+  elements: ClassElement[];
 }
 
 declare export class ClassElement extends Term {
   isStatic: any; // boolean
-  accessModifier: any; // 'public' | 'protected' | 'private'
+  method: MethodDefinition;
 }
 
-declare export class MethodClassElement extends ClassElement {
+declare export class TsClassExpression extends Expression {
+  name?: BindingIdentifier;
+  typeParameters?: TsTypeParameterDeclaration[];
+  heritageClauses?: TsHeritageClause[];
+  elements: (TsClassElement | TsIndexSignatureDeclaration)[];
+}
+
+declare export class TsClassDeclaration extends Statement {
+  isAbstract: any; // boolean
+  name: BindingIdentifier;
+  typeParameters?: TsTypeParameterDeclaration[];
+  heritageClauses?: TsHeritageClause[];
+  elements: (TsClassElement | TsIndexSignatureDeclaration)[];
+}
+
+declare export class TsClassElement extends Term {
+  isStatic: any; // boolean
+  accessModifier?: any; // 'public' | 'protected' | 'private'
+}
+
+declare export class TsMethodClassElement extends TsClassElement {
   hasQuestionToken: any; // boolean
   method: MethodDefinition;
 }
 
-declare export class AbstractMethodClassElement extends ClassElement {
+declare export class TsAbstractMethodClassElement extends TsClassElement {
   hasQuestionToken: any; // boolean
-  method: AbstractMethodDefinition;
+  method: TsAbstractMethodDefinition;
 }
 
-declare export class ConstructorClassElement extends ClassElement {
-  params: ConstructorFormalParameters;
+declare export class TsConstructorClassElement extends TsClassElement {
+  params: TsConstructorFormalParameters;
   body: FunctionBody;
 }
 
-declare export class ConstructorFormalParameters extends Term {
-  items: ConstructorParameterDeclaration[];
+declare export class TsConstructorFormalParameters extends Term {
+  items: TsConstructorParameterDeclaration[];
   rest?: ParameterDeclaration;
 }
 
-declare export class ConstructorParameterDeclaration extends ParameterDeclarationBase {
+declare export class TsConstructorParameterDeclaration extends ParameterDeclarationBase {
   accessModifier?: any; // 'public' | 'protected' | 'private'
   hasReadonlyModifier: any; // boolean
 }
 
-declare export class PropertyDeclaration extends ClassElement {
+declare export class TsPropertyDeclaration extends TsClassElement {
   hasReadonlyModifier: any; // boolean
   name: PropertyName;
   hasQuestionToken: any; // boolean
-  type?: TypeNode;
+  type?: TsTypeNode;
   initializer?: Expression;
 }
 
@@ -197,14 +214,14 @@ declare export class PropertyDeclaration extends ClassElement {
 
 // interface
 
-declare export class InterfaceDeclaration extends Statement {
-  name: BindingIdentifier;
-  typeParameters?: TypeParameterDeclaration[];
-  heritageClauses?: HeritageClause[];
-  elements: (TypeElement | IndexSignatureDeclaration)[];
-}
+declare export class InterfaceDeclaration extends Statement {}
 
-declare export class TypeElement extends Term {}
+declare export class TsInterfaceDeclaration extends InterfaceDeclaration {
+  name: BindingIdentifier;
+  typeParameters?: TsTypeParameterDeclaration[];
+  heritageClauses?: TsHeritageClause[];
+  elements: (TsTypeElement | TsIndexSignatureDeclaration)[];
+}
 
 // TypeScript interface elements
 declare export class TsTypeElement extends TypeElement {}
@@ -222,7 +239,7 @@ declare export class TsMethodSignature extends FunctionSignatureLikeTsTypeElemen
 declare export class TsCallSignatureDeclaration extends FunctionSignatureLikeTsTypeElement {}
 
 declare export class TsConstructorSignatureDeclaration extends FunctionSignatureLikeTsTypeElement {
-  // note: TypeScript does not allow ConstructorFormalParameters here
+  // note: TypeScript does not allow TsConstructorFormalParameters here
 }
 
 declare export class TsPropertySignature extends TsTypeElement {
@@ -234,19 +251,19 @@ declare export class TsPropertySignature extends TsTypeElement {
 
 
 
-// common for classes and interfaces
+// common for TypeScript classes and interfaces
 
-declare export class HeritageClause extends Term {
-  parent?: ClassExpression | ClassDeclaration | InterfaceDeclaration;
-  types: ExpressionWithTypeArguments[];
+declare export class TsHeritageClause extends Term {
+  parent?: TsClassExpression | TsClassDeclaration | TsInterfaceDeclaration;
+  types: ExpressionWithTsTypeArguments[];
 }
-declare export class ExtendsClause extends HeritageClause {}
-declare export class ImplementsClause extends HeritageClause {}
+declare export class TsExtendsClause extends TsHeritageClause {}
+declare export class TsImplementsClause extends TsHeritageClause {}
 
-declare export class IndexSignatureDeclaration extends Term {
-  parent?: ClassExpression | ClassDeclaration | InterfaceDeclaration | TsTypeLiteralNode;
+declare export class TsIndexSignatureDeclaration extends Term {
+  parent?: TsClassExpression | TsClassDeclaration | TsInterfaceDeclaration | TsTypeLiteralNode;
   parameter: ParameterDeclaration;
-  valueType: TypeNode;
+  valueType: TsTypeNode;
 }
 
 
@@ -257,7 +274,7 @@ declare export class TypeAliasDeclaration extends Statement {}
 
 declare export class TsTypeAliasDeclaration extends TypeAliasDeclaration {
   name: BindingIdentifier;
-  typeParameters?: TypeParameterDeclaration[];
+  typeParameters?: TsTypeParameterDeclaration[];
   type: TypeNode;
 }
 
@@ -281,6 +298,7 @@ declare export class TsEnumElement extends Term {
 
 
 // modules
+
 declare export class Module extends Term {
   directives: any[];
   items : Term[];
@@ -322,11 +340,11 @@ declare export class ExportLocals extends ExportDeclaration {
 }
 
 declare export class Export extends ExportDeclaration {
-  declaration: FunctionDeclaration | ClassDeclaration | VariableDeclaration;
+  declaration: FunctionDeclaration | ClassDeclaration | TsClassDeclaration | VariableDeclaration;
 }
 
 declare export class ExportDefault extends ExportDeclaration {
-  body: FunctionDeclaration | ClassDeclaration | Expression;
+  body: FunctionDeclaration | ClassDeclaration | TsClassDeclaration | Expression;
 }
 
 declare export class ExportFromSpecifier extends Term {
@@ -342,34 +360,34 @@ declare export class ExportLocalSpecifier extends Term {
 
 // property definition
 declare export class Method extends MethodDefinition {
-  parent?: ClassExpression | ClassDeclaration | ObjectExpression;
+  parent?: ClassExpression | ClassDeclaration | ObjectExpression | TsClassExpression | TsClassDeclaration;
   isAsync: any;
   isGenerator: any;
   params: FormalParameters;
 }
 
-declare export class AbstractMethod extends AbstractMethodDefinition {
-  parent?: ClassExpression | ClassDeclaration;
+declare export class TsAbstractMethod extends TsAbstractMethodDefinition {
+  parent?: TsClassExpression | TsClassDeclaration;
   isAsync: any; // boolean
   isGenerator: any; // boolean
   params: FormalParameters;
 }
 
 declare export class Getter extends MethodDefinition {
-  parent?: ClassExpression | ClassDeclaration | ObjectExpression;
+  parent?: ClassExpression | ClassDeclaration | ObjectExpression | TsClassExpression | TsClassDeclaration;
 }
 
-declare export class AbstractGetter extends AbstractMethodDefinition {
-  parent?: ClassExpression | ClassDeclaration;
+declare export class TsAbstractGetter extends TsAbstractMethodDefinition {
+  parent?: TsClassExpression | TsClassDeclaration;
 }
 
 declare export class Setter extends MethodDefinition {
-  parent?: ClassExpression | ClassDeclaration | ObjectExpression;
+  parent?: ClassExpression | ClassDeclaration | ObjectExpression | TsClassExpression | TsClassDeclaration;
   param: ParameterDeclaration;
 }
 
-declare export class AbstractSetter extends AbstractMethodDefinition {
-  parent?: ClassExpression | ClassDeclaration;
+declare export class TsAbstractSetter extends TsAbstractMethodDefinition {
+  parent?: TsClassExpression | TsClassDeclaration;
   param: ParameterDeclaration;
 }
 
@@ -768,7 +786,7 @@ declare export class TypeParameterDeclaration extends Term {}
 declare export class TsTypeNode extends TypeNode {}
 
 declare export class TsTypeParameterDeclaration extends TypeParameterDeclaration {
-  parent?: ClassExpression | ClassDeclaration | InterfaceDeclaration | TsTypeAliasDeclaration | ArrowExpression | FunctionDeclaration | SignatureTsTypeNode | MappedTsTypeNode;
+  parent?: TsClassExpression | TsClassDeclaration | TsInterfaceDeclaration | TsTypeAliasDeclaration | ArrowExpression | FunctionDeclaration | SignatureTsTypeNode | MappedTsTypeNode;
   name: any; // Identifier
   constraint?: TsTypeNode;
   default?: TsTypeNode;
@@ -781,7 +799,6 @@ declare export class TsKeywordTypeNode extends TsTypeNode {
              // 'this' | 'void' | 'undefined' | 'null' | 'never'
 }
 
-// type FunctionOrConstructorTypeNode = FunctionTypeNode | ConstructorTypeNode
 declare export class SignatureTsTypeNode extends TsTypeNode {
   typeParameters?: TsTypeParameterDeclaration[];
   params: FormalParameters;
@@ -792,8 +809,6 @@ declare export class FunctionTsTypeNode extends SignatureTsTypeNode {}
 // example: `new (i: number, s: string) => SomeClass`
 declare export class ConstructorTsNodeType extends SignatureTsTypeNode {}
 
-// type TypeReferenceType = TypeReferenceNode | ExpressionWithTypeArguments;
-
 declare export class TsTypeReferenceNode extends TsTypeNode {
   typeName: any; // Identifier
   typeArguments?: TypeNode[];
@@ -801,7 +816,7 @@ declare export class TsTypeReferenceNode extends TsTypeNode {
 
 // example: `SomeMapWithGenericClassValues["key"]<number, string>`
 declare export class ExpressionWithTsTypeArguments extends TsTypeNode {
-  parent?: HeritageClause;
+  parent?: TsHeritageClause;
   /*
    * In TypeScript, the "destination" class/interface of a heritage clause is
    * allowed to be an arbitrary `LeftHandSideExpression`` which would perhaps
@@ -831,7 +846,7 @@ declare export class TsTypeQueryNode extends TsTypeNode {
 
 // example: `{ readonly someKey: number }`
 declare export class TsTypeLiteralNode extends TsTypeNode {
-  members: (TsTypeElement | IndexSignatureDeclaration)[];
+  members: (TsTypeElement | TsIndexSignatureDeclaration)[];
 }
 
 // example: `string[]`

--- a/src/term-spec.js
+++ b/src/term-spec.js
@@ -45,6 +45,13 @@ declare export class VariableReference extends Term {
   name: any; // Identifier (string)
 }
 
+declare export class ParameterDeclarationBase extends Term {
+  // binding: Binding | BindingWithDefault;
+  binding: ObjectBinding | ArrayBinding | BindingIdentifier | MemberExpression | BindingWithDefault;
+  hasQuestionToken: any; // boolean
+  type?: TypeNode;
+}
+
 /* ***** Bindings ***** */
 
 // type Binding = (ObjectBinding | ArrayBinding | BindingIdentifier | MemberExpression);
@@ -172,10 +179,9 @@ declare export class ConstructorFormalParameters extends Term {
   rest?: ParameterDeclaration;
 }
 
-declare export class ConstructorParameterDeclaration extends Term {
+declare export class ConstructorParameterDeclaration extends ParameterDeclarationBase {
   accessModifier?: any; // 'public' | 'protected' | 'private'
   hasReadonlyModifier: any; // boolean
-  parameter: ParameterDeclaration;
 }
 
 declare export class PropertyDeclaration extends ClassElement {
@@ -664,12 +670,7 @@ declare export class FormalParameters extends Term {
   rest?: ParameterDeclaration;
 }
 
-declare export class ParameterDeclaration extends Term {
-  // binding: Binding | BindingWithDefault;
-  binding: ObjectBinding | ArrayBinding | BindingIdentifier | MemberExpression | BindingWithDefault;
-  hasQuestionToken: any; // boolean
-  type?: TypeNode;
-}
+declare export class ParameterDeclaration extends ParameterDeclarationBase {}
 
 declare export class FunctionBody extends Term {
   directives: any[];

--- a/src/term-spec.js
+++ b/src/term-spec.js
@@ -140,40 +140,46 @@ declare export class AssignmentTargetPropertyProperty extends AssignmentTargetPr
 
 // class
 
-declare export class ClassExpression extends Expression {
+declare export class ClassExpressionBase extends Expression {
   name?: BindingIdentifier;
-  super?: Expression;
-  elements: ClassElement[];
 }
 
-declare export class ClassDeclaration extends Statement {
+declare export class ClassDeclarationBase extends Statement {
   name: BindingIdentifier;
+}
+
+declare export class ClassExpression extends ClassExpressionBase {
   super?: Expression;
   elements: ClassElement[];
 }
 
-declare export class ClassElement extends Term {
+declare export class ClassDeclaration extends ClassDeclarationBase {
+  super?: Expression;
+  elements: ClassElement[];
+}
+
+declare export class TsClassExpression extends ClassExpressionBase {
+  typeParameters?: TsTypeParameterDeclaration[];
+  heritageClauses?: TsHeritageClause[];
+  elements: (TsClassElement | TsIndexSignatureDeclaration)[];
+}
+
+declare export class TsClassDeclaration extends ClassDeclarationBase {
+  isAbstract: any; // boolean
+  typeParameters?: TsTypeParameterDeclaration[];
+  heritageClauses?: TsHeritageClause[];
+  elements: (TsClassElement | TsIndexSignatureDeclaration)[];
+}
+
+declare export class ClassElementBase extends Term {
   isStatic: any; // boolean
+}
+
+declare export class ClassElement extends ClassElementBase {
   method: MethodDefinition;
 }
 
-declare export class TsClassExpression extends Expression {
-  name?: BindingIdentifier;
-  typeParameters?: TsTypeParameterDeclaration[];
-  heritageClauses?: TsHeritageClause[];
-  elements: (TsClassElement | TsIndexSignatureDeclaration)[];
-}
-
-declare export class TsClassDeclaration extends Statement {
-  isAbstract: any; // boolean
-  name: BindingIdentifier;
-  typeParameters?: TsTypeParameterDeclaration[];
-  heritageClauses?: TsHeritageClause[];
-  elements: (TsClassElement | TsIndexSignatureDeclaration)[];
-}
-
-declare export class TsClassElement extends Term {
-  isStatic: any; // boolean
+declare export class TsClassElement extends ClassElementBase {
   accessModifier?: any; // 'public' | 'protected' | 'private'
 }
 
@@ -361,8 +367,9 @@ declare export class ExportLocalSpecifier extends Term {
 // property definition
 declare export class Method extends MethodDefinition {
   parent?: ClassExpression | ClassDeclaration | ObjectExpression | TsClassExpression | TsClassDeclaration;
-  isAsync: any;
-  isGenerator: any;
+  isAsync: any; // boolean
+  isGenerator: any; // boolean
+  typeParameters?: TypeParameterDeclaration[];
   params: FormalParameters;
 }
 
@@ -370,6 +377,7 @@ declare export class TsAbstractMethod extends TsAbstractMethodDefinition {
   parent?: TsClassExpression | TsClassDeclaration;
   isAsync: any; // boolean
   isGenerator: any; // boolean
+  typeParameters?: TypeParameterDeclaration[];
   params: FormalParameters;
 }
 

--- a/src/term-spec.js
+++ b/src/term-spec.js
@@ -411,9 +411,9 @@ declare export class CallExpression extends Expression {
   typeArguments?: TypeNode[];
   arguments: (SpreadElement | Expression)[];
 }
-
 declare export class CallExpressionE extends Expression {
   callee: Expression | Super;
+  typeArguments?: TypeNode[];
   arguments: Term[];
 }
 
@@ -454,6 +454,7 @@ declare export class IdentifierExpression extends Expression {
 
 declare export class NewExpression extends Expression {
   callee: Expression;
+  typeArguments?: TypeNode[];
   arguments: (SpreadElement | Expression)[];
 }
 
@@ -502,6 +503,15 @@ declare export class ParenthesizedExpression extends Expression {
   inner: any;
 }
 
+declare export class AsExpression extends Expression {
+  expression: Expression;
+  type: TypeNode;
+}
+
+declare export class TypeAssertion extends UnaryExpression {
+  type: TypeNode;
+  expression: UnaryExpression;
+}
 
 // statements
 declare export class BlockStatement extends Statement {

--- a/src/term-spec.js
+++ b/src/term-spec.js
@@ -442,7 +442,6 @@ declare export class ArrayExpression extends Expression {
 
 declare export class ArrowExpression extends Expression {
   isAsync: any; // boolean
-  isGenerator: any; // boolean
   typeParameters?: TypeParameterDeclaration[];
   params: FormalParameters;
   type?: TypeNode;
@@ -450,7 +449,6 @@ declare export class ArrowExpression extends Expression {
 }
 declare export class ArrowExpressionE extends Expression {
   isAsync: any; // boolean
-  isGenerator: any; // boolean
   typeParameters?: TypeParameterDeclaration[];
   params: FormalParameters;
   type?: TypeNode;

--- a/src/term-spec.js
+++ b/src/term-spec.js
@@ -178,8 +178,6 @@ declare export class ConstructorParameterDeclaration extends Term {
   parameter: ParameterDeclaration;
 }
 
-declare export class SemicolonClassElement extends ClassElement {}
-
 declare export class PropertyDeclaration extends ClassElement {
   hasReadonlyModifier: any; // boolean
   name: PropertyName;

--- a/src/term-spec.js
+++ b/src/term-spec.js
@@ -32,7 +32,7 @@ declare export class NamedObjectProperty extends ObjectProperty {
   name: PropertyName;
 }
 declare export class MethodDefinition extends NamedObjectProperty {
-  body: FunctionBody;
+  body?: FunctionBody; // undefined only on abstract class methods
 }
 
 declare export class VariableReference extends Term {
@@ -134,6 +134,7 @@ declare export class ClassExpression extends Expression {
 }
 
 declare export class ClassDeclaration extends Statement {
+  isAbstract: any; // boolean
   name: BindingIdentifier;
   typeParameters?: TypeParameterDeclaration[];
   heritageClauses?: HeritageClause[];
@@ -141,9 +142,42 @@ declare export class ClassDeclaration extends Statement {
 }
 
 declare export class ClassElement extends Term {
-  isStatic: any;
+  isStatic: any; // boolean
+  accessModifier: any; // 'public' | 'protected' | 'private'
+}
+
+declare export class MethodClassElement extends ClassElement {
+  isAbstract: any; // boolean
+  hasQuestionToken: any; // boolean
   method: MethodDefinition;
 }
+
+declare export class ConstructorClassElement extends ClassElement {
+  params: ConstructorFormalParameters;
+  body: FunctionBody;
+}
+
+declare export class ConstructorFormalParameters extends Term {
+  items: ConstructorParameterDeclaration[];
+  rest?: ParameterDeclaration;
+}
+
+declare export class ConstructorParameterDeclaration extends Term {
+  accessModifier?: any; // 'public' | 'protected' | 'private'
+  hasReadonlyModifier: any; // boolean
+  parameter: ParameterDeclaration;
+}
+
+declare export class SemicolonClassElement extends ClassElement {}
+
+declare export class PropertyDeclaration extends ClassElement {
+  hasQuestionToken: any; // boolean
+  name: PropertyName;
+  type?: TypeNode;
+  initializer?: Expression;
+}
+
+
 
 // interface
 
@@ -532,7 +566,7 @@ declare export class FormalParameters extends Term {
 }
 
 declare export class ParameterDeclaration extends Term {
-  // modifiers: ('public' | 'protected' | 'private' | 'static' | 'readonly')[]
+  // modifiers: ('public' | 'protected' | 'private' | 'readonly')[]
   modifiers?: any[];
   // binding: Binding | BindingWithDefault;
   binding: ObjectBinding | ArrayBinding | BindingIdentifier | MemberExpression | BindingWithDefault;

--- a/src/term-spec.js
+++ b/src/term-spec.js
@@ -32,7 +32,13 @@ declare export class NamedObjectProperty extends ObjectProperty {
   name: PropertyName;
 }
 declare export class MethodDefinition extends NamedObjectProperty {
-  body?: FunctionBody; // undefined only on abstract class methods
+  type?: TypeNode;
+  body: FunctionBody;
+}
+
+declare export class AbstractMethodDefinition extends Term {
+  name: PropertyName;
+  type?: TypeNode;
 }
 
 declare export class VariableReference extends Term {
@@ -147,9 +153,13 @@ declare export class ClassElement extends Term {
 }
 
 declare export class MethodClassElement extends ClassElement {
-  isAbstract: any; // boolean
   hasQuestionToken: any; // boolean
   method: MethodDefinition;
+}
+
+declare export class AbstractMethodClassElement extends ClassElement {
+  hasQuestionToken: any; // boolean
+  method: AbstractMethodDefinition;
 }
 
 declare export class ConstructorClassElement extends ClassElement {
@@ -326,14 +336,29 @@ declare export class Method extends MethodDefinition {
   params: FormalParameters;
 }
 
+declare export class AbstractMethod extends AbstractMethodDefinition {
+  parent?: ClassExpression | ClassDeclaration;
+  isAsync: any; // boolean
+  isGenerator: any; // boolean
+  params: FormalParameters;
+}
+
 declare export class Getter extends MethodDefinition {
   parent?: ClassExpression | ClassDeclaration | ObjectExpression;
 }
 
+declare export class AbstractGetter extends AbstractMethodDefinition {
+  parent?: ClassExpression | ClassDeclaration;
+}
+
 declare export class Setter extends MethodDefinition {
   parent?: ClassExpression | ClassDeclaration | ObjectExpression;
-  param: ObjectBinding | ArrayBinding | BindingIdentifier | MemberExpression | BindingWithDefault;
-  // param: Binding or BindingWithDefault;
+  param: ParameterDeclaration;
+}
+
+declare export class AbstractSetter extends AbstractMethodDefinition {
+  parent?: ClassExpression | ClassDeclaration;
+  param: ParameterDeclaration;
 }
 
 declare export class DataProperty extends NamedObjectProperty {

--- a/src/term-spec.js
+++ b/src/term-spec.js
@@ -130,7 +130,7 @@ declare export class ClassExpression extends Expression {
   name?: BindingIdentifier;
   typeParameters?: TypeParameterDeclaration[];
   heritageClauses?: HeritageClause[];
-  elements: ClassElement[];
+  elements: (ClassElement | IndexSignatureDeclaration)[];
 }
 
 declare export class ClassDeclaration extends Statement {
@@ -138,7 +138,7 @@ declare export class ClassDeclaration extends Statement {
   name: BindingIdentifier;
   typeParameters?: TypeParameterDeclaration[];
   heritageClauses?: HeritageClause[];
-  elements: ClassElement[];
+  elements: (ClassElement | IndexSignatureDeclaration)[];
 }
 
 declare export class ClassElement extends Term {
@@ -181,8 +181,40 @@ declare export class PropertyDeclaration extends ClassElement {
 
 // interface
 
-// FIXME add real definition
-declare export class InterfaceDeclaration extends Statement {}
+declare export class InterfaceDeclaration extends Statement {
+  name: BindingIdentifier;
+  typeParameters?: TypeParameterDeclaration[];
+  heritageClauses?: HeritageClause[];
+  elements: (TypeElement | IndexSignatureDeclaration)[];
+}
+
+declare export class TypeElement extends Term {}
+
+declare export class FunctionSignatureLikeTypeElement extends TypeElement {
+  typeParameters?: TypeParameterDeclaration[];
+  params: FormalParameters;
+  type?: TypeNode;
+}
+
+declare export class MethodSignature extends FunctionSignatureLikeTypeElement {
+  name: PropertyName;
+}
+
+declare export class CallSignatureDeclaration extends FunctionSignatureLikeTypeElement {}
+
+declare export class ConstructorSignatureDeclaration extends FunctionSignatureLikeTypeElement {
+  // note: TypeScript does not allow ConstructorFormalParameters here
+}
+
+declare export class PropertySignature extends TypeElement {
+  name: PropertyName;
+  hasQuestionToken: any; // boolean
+  type?: TypeNode;
+}
+
+
+
+// common for classes and interfaces
 
 declare export class HeritageClause extends Term {
   parent?: InterfaceDeclaration | ClassExpression | ClassDeclaration;
@@ -191,10 +223,19 @@ declare export class HeritageClause extends Term {
 declare export class ExtendsClause extends HeritageClause {}
 declare export class ImplementsClause extends HeritageClause {}
 
+declare export class IndexSignatureDeclaration extends Term {
+  parameter: ParameterDeclaration;
+  valueType: TypeNode;
+}
+
+
+
 // type alias
 
 // FIXME add real definition
-declare export class TypeAlias extends Statement {}
+declare export class TypeAliasDeclaration extends Statement {}
+
+
 
 // modules
 declare export class Module extends Term {
@@ -649,14 +690,18 @@ declare export class OperatorDeclarator extends VariableDeclarator {
   assoc: any;
 }
 
-declare export class TypeNode extends Term {}
+
+
+// type annotations
 
 declare export class TypeParameterDeclaration extends Term {
-  parent?: ClassExpression | ClassDeclaration | InterfaceDeclaration | TypeAlias | ArrowExpression | FunctionDeclaration | SignatureTypeNode | MappedTypeNode;
+  parent?: ClassExpression | ClassDeclaration | InterfaceDeclaration | TypeAliasDeclaration | ArrowExpression | FunctionDeclaration | SignatureTypeNode | MappedTypeNode;
   name: any; // Identifier
   constraint?: TypeNode;
   default?: TypeNode;
 }
+
+declare export class TypeNode extends Term {}
 
 // Note: TypeScript also has a separate ThisTypeNode interface that is
 //       not reflected here
@@ -715,7 +760,7 @@ declare export class TypeQueryNode extends TypeNode {
 
 // example: `{ readonly someKey: number }`
 declare export class TypeLiteralNode extends TypeNode {
-  members: TypeElement[];
+  members: (TypeElement | IndexSignatureDeclaration)[];
 }
 
 // example: `string[]`
@@ -757,9 +802,6 @@ declare export class IndexedAccessTypeNode extends TypeNode {
   objectType: TypeNode;
   indexType: TypeNode;
 }
-
-// FIXME add actual definition
-declare export class TypeAliasDeclaration extends Term {}
 
 // example: `{ readonly [K in "some" | "permissible" | "keys"]: string }`
 declare export class MappedTypeNode extends TypeNode {

--- a/src/term-spec.js
+++ b/src/term-spec.js
@@ -52,15 +52,15 @@ declare export class BindingIdentifier extends VariableReference { }
 
 declare export class AssignmentTargetIdentifier extends VariableReference { }
 
-declare export class MemberAssignmentTarget extends Term { 
+declare export class MemberAssignmentTarget extends Term {
   object: Expression | Super;
 }
 
-declare export class ComputedMemberAssignmentTarget extends MemberAssignmentTarget { 
+declare export class ComputedMemberAssignmentTarget extends MemberAssignmentTarget {
   expression: Expression;
 }
 
-declare export class StaticMemberAssignmentTarget extends MemberAssignmentTarget { 
+declare export class StaticMemberAssignmentTarget extends MemberAssignmentTarget {
   property: any;
 }
 
@@ -89,8 +89,8 @@ declare export class BindingPropertyProperty extends BindingProperty {
 }
 
 /*
-  AssignmentTarget = 
-      ObjectAssignmentTarget 
+  AssignmentTarget =
+      ObjectAssignmentTarget
     | ArrayAssignmentTarget
     | AssignmentTargetIdentifier
     | MemberAssignmentTarget
@@ -113,12 +113,12 @@ declare export class ObjectAssignmentTarget extends Term {
 
 declare export class AssignmentTargetProperty extends Term { }
 
-declare export class AssignmentTargetPropertyIdentifier extends AssignmentTargetProperty { 
+declare export class AssignmentTargetPropertyIdentifier extends AssignmentTargetProperty {
   binding: AssignmentTargetIdentifier;
   init?: Expression;
 }
 
-declare export class AssignmentTargetPropertyProperty extends AssignmentTargetProperty { 
+declare export class AssignmentTargetPropertyProperty extends AssignmentTargetProperty {
   name: PropertyName;
   binding?: ObjectAssignmentTarget | ArrayAssignmentTarget | AssignmentTargetIdentifier | MemberAssignmentTarget | AssignmentTargetWithDefault;
 }
@@ -572,4 +572,132 @@ declare export class VariableDeclarator extends Term {
 declare export class OperatorDeclarator extends VariableDeclarator {
   prec: any;
   assoc: any;
+}
+
+declare export class TypeNode extends Term {}
+
+// FIXME add actual definition
+declare export class TypeParameterDeclaration extends Term {}
+
+// FIXME add actual definition
+declare export class ParameterDeclaration extends Term {}
+
+// Note: TypeScript also has a separate ThisTypeNode interface that is
+//       not reflected here
+declare export class KeywordTypeNode extends TypeNode {
+  kind: any; // 'any' | 'number' | 'object' | 'boolean' | 'string' | 'symbol' |
+             // 'this' | 'void' | 'undefined' | 'null' | 'never'
+}
+
+// type FunctionOrConstructorTypeNode = FunctionTypeNode | ConstructorTypeNode
+declare export class SignatureTypeNode extends TypeNode {
+  typeParameters?: TypeParameterDeclaration[];
+  parameters: ParameterDeclaration[];
+  type?: TypeNode;
+}
+// example: `(i: number, s: string) => boolean`
+declare export class FunctionTypeNode extends SignatureTypeNode {}
+// example: `new (i: number, s: string) => SomeClass`
+declare export class ConstructorNodeType extends SignatureTypeNode {}
+
+// type TypeReferenceType = TypeReferenceNode | ExpressionWithTypeArguments;
+
+declare export class TypeReferenceNode extends TypeNode {
+  typeName: any; // Identifier
+  typeArguments?: TypeNode[];
+}
+
+// FIXME add actual definition
+declare export class HeritageClause extends Term {}
+
+// example: `SomeMapWithGenericClassValues["key"]<number, string>`
+declare export class ExpressionWithTypeArguments extends TypeNode {
+  parent?: HeritageClause;
+  /*
+   * In TypeScript, the "destination" class/interface of a heritage clause is
+   * allowed to be an arbitrary `LeftHandSideExpression`` which would perhaps
+   * best translate into `AssignmentTarget`. However, in the original version
+   * of this spec, the superclass is an arbitrary Expression, so here we retain
+   * that permissiveness.
+   */
+  expression: Expression;
+  typeArguments?: TypeNode[];
+}
+
+// example 1:
+//   `something is string` in a boolean-returning function declared as
+//   `function isString(something: any): something is string`
+// example 2:
+//   `this is string` in a boolean-returning class method declared as
+//   `isString(): this is string`
+declare export class TypePredicateNode extends TypeNode {
+  parameterName: any; //  Identifier | 'this'
+  type: TypeNode;
+}
+
+// example: `typeof someVariable`
+declare export class TypeQueryNode extends TypeNode {
+  exprName: any; // Identifier
+}
+
+// example: `{ readonly someKey: number }`
+declare export class TypeLiteralNode extends TypeNode {
+  members: TypeElement[];
+}
+
+// example: `string[]`
+declare export class ArrayTypeNode extends TypeNode {
+  elementType: TypeNode;
+}
+
+// example: `[string, number]`
+declare export class TupleTypeNode extends TypeNode {
+  elementTypes: TypeNode[];
+}
+
+// example: `number | string`
+declare export class UnionTypeNode extends TypeNode {
+  types: TypeNode[];
+}
+
+// example: `number & string`
+declare export class IntersectionTypeNode extends TypeNode {
+  types: TypeNode[];
+}
+
+// example: `(number)`
+declare export class ParenthesizedTypeNode extends TypeNode {
+  type: TypeNode;
+}
+
+// example: `keyof { a: number, b: string }`
+declare export class TypeOperatorNode extends TypeNode {
+  operator: any; // 'keyof'
+  type: TypeNode;
+}
+
+// example:
+//   `SomeClass[number]`
+//   where
+//   `class SomeClass { [index: number]: string }`
+declare export class IndexedAccessTypeNode extends TypeNode {
+  objectType: TypeNode;
+  indexType: TypeNode;
+}
+
+// FIXME add actual definition
+declare export class TypeAliasDeclaration extends Term {}
+
+// example: `{ readonly [K in "some" | "permissible" | "keys"]: string }`
+declare export class MappedTypeNode extends TypeNode {
+  parent?: TypeAliasDeclaration;
+  hasReadonlyToken: any; // boolean
+  typeParameter: TypeParameterDeclaration;
+  hasQuestionToken: any; // boolean
+  type?: TypeNode;
+}
+
+// examples: `"someValue"`, `42`, `null`, `false`
+declare export class LiteralTypeNode extends TypeNode {
+  literal: Expression;
 }

--- a/src/term-spec.js
+++ b/src/term-spec.js
@@ -232,8 +232,25 @@ declare export class IndexSignatureDeclaration extends Term {
 
 // type alias
 
-// FIXME add real definition
-declare export class TypeAliasDeclaration extends Statement {}
+declare export class TypeAliasDeclaration extends Statement {
+  name: BindingIdentifier;
+  typeParameters?: TypeParameterDeclaration[];
+  type: TypeNode;
+}
+
+
+
+// enum
+
+declare export class EnumDeclaration extends Statement {
+  name: BindingIdentifier;
+  elements: EnumElement[];
+}
+
+declare export class EnumElement extends Term {
+  name: PropertyName;
+  initializer?: Expression;
+}
 
 
 

--- a/src/term-spec.js
+++ b/src/term-spec.js
@@ -171,8 +171,9 @@ declare export class ConstructorParameterDeclaration extends Term {
 declare export class SemicolonClassElement extends ClassElement {}
 
 declare export class PropertyDeclaration extends ClassElement {
-  hasQuestionToken: any; // boolean
+  hasReadonlyModifier: any; // boolean
   name: PropertyName;
+  hasQuestionToken: any; // boolean
   type?: TypeNode;
   initializer?: Expression;
 }
@@ -207,6 +208,7 @@ declare export class ConstructorSignatureDeclaration extends FunctionSignatureLi
 }
 
 declare export class PropertySignature extends TypeElement {
+  hasReadonlyModifier: any; // boolean
   name: PropertyName;
   hasQuestionToken: any; // boolean
   type?: TypeNode;

--- a/src/term-spec.js
+++ b/src/term-spec.js
@@ -346,11 +346,11 @@ declare export class ExportLocals extends ExportDeclaration {
 }
 
 declare export class Export extends ExportDeclaration {
-  declaration: FunctionDeclaration | ClassDeclaration | TsClassDeclaration | VariableDeclaration;
+  declaration: FunctionDeclaration | ClassDeclarationBase | VariableDeclaration;
 }
 
 declare export class ExportDefault extends ExportDeclaration {
-  body: FunctionDeclaration | ClassDeclaration | TsClassDeclaration | Expression;
+  body: FunctionDeclaration | ClassDeclarationBase | Expression;
 }
 
 declare export class ExportFromSpecifier extends Term {
@@ -366,7 +366,7 @@ declare export class ExportLocalSpecifier extends Term {
 
 // property definition
 declare export class Method extends MethodDefinition {
-  parent?: ClassExpression | ClassDeclaration | ObjectExpression | TsClassExpression | TsClassDeclaration;
+  parent?: ClassExpressionBase | ClassDeclarationBase | ObjectExpression;
   isAsync: any; // boolean
   isGenerator: any; // boolean
   typeParameters?: TypeParameterDeclaration[];
@@ -382,7 +382,7 @@ declare export class TsAbstractMethod extends TsAbstractMethodDefinition {
 }
 
 declare export class Getter extends MethodDefinition {
-  parent?: ClassExpression | ClassDeclaration | ObjectExpression | TsClassExpression | TsClassDeclaration;
+  parent?: ClassExpressionBase | ClassDeclarationBase | ObjectExpression;
 }
 
 declare export class TsAbstractGetter extends TsAbstractMethodDefinition {
@@ -390,7 +390,7 @@ declare export class TsAbstractGetter extends TsAbstractMethodDefinition {
 }
 
 declare export class Setter extends MethodDefinition {
-  parent?: ClassExpression | ClassDeclaration | ObjectExpression | TsClassExpression | TsClassDeclaration;
+  parent?: ClassExpressionBase | ClassDeclarationBase | ObjectExpression;
   param: ParameterDeclaration;
 }
 

--- a/src/term-spec.js
+++ b/src/term-spec.js
@@ -139,6 +139,7 @@ declare export class AssignmentTargetPropertyProperty extends AssignmentTargetPr
 
 
 // class
+
 declare export class ClassExpression extends Expression {
   name?: BindingIdentifier;
   typeParameters?: TypeParameterDeclaration[];
@@ -205,27 +206,30 @@ declare export class InterfaceDeclaration extends Statement {
 
 declare export class TypeElement extends Term {}
 
-declare export class FunctionSignatureLikeTypeElement extends TypeElement {
-  typeParameters?: TypeParameterDeclaration[];
+// TypeScript interface elements
+declare export class TsTypeElement extends TypeElement {}
+
+declare export class FunctionSignatureLikeTsTypeElement extends TsTypeElement {
+  typeParameters?: TsTypeParameterDeclaration[];
   params: FormalParameters;
-  type?: TypeNode;
+  type?: TsTypeNode;
 }
 
-declare export class MethodSignature extends FunctionSignatureLikeTypeElement {
+declare export class TsMethodSignature extends FunctionSignatureLikeTsTypeElement {
   name: PropertyName;
 }
 
-declare export class CallSignatureDeclaration extends FunctionSignatureLikeTypeElement {}
+declare export class TsCallSignatureDeclaration extends FunctionSignatureLikeTsTypeElement {}
 
-declare export class ConstructorSignatureDeclaration extends FunctionSignatureLikeTypeElement {
+declare export class TsConstructorSignatureDeclaration extends FunctionSignatureLikeTsTypeElement {
   // note: TypeScript does not allow ConstructorFormalParameters here
 }
 
-declare export class PropertySignature extends TypeElement {
+declare export class TsPropertySignature extends TsTypeElement {
   hasReadonlyModifier: any; // boolean
   name: PropertyName;
   hasQuestionToken: any; // boolean
-  type?: TypeNode;
+  type?: TsTypeNode;
 }
 
 
@@ -240,7 +244,7 @@ declare export class ExtendsClause extends HeritageClause {}
 declare export class ImplementsClause extends HeritageClause {}
 
 declare export class IndexSignatureDeclaration extends Term {
-  parent?: ClassExpression | ClassDeclaration | InterfaceDeclaration | TypeLiteralNode;
+  parent?: ClassExpression | ClassDeclaration | InterfaceDeclaration | TsTypeLiteralNode;
   parameter: ParameterDeclaration;
   valueType: TypeNode;
 }
@@ -249,7 +253,9 @@ declare export class IndexSignatureDeclaration extends Term {
 
 // type alias
 
-declare export class TypeAliasDeclaration extends Statement {
+declare export class TypeAliasDeclaration extends Statement {}
+
+declare export class TsTypeAliasDeclaration extends TypeAliasDeclaration {
   name: BindingIdentifier;
   typeParameters?: TypeParameterDeclaration[];
   type: TypeNode;
@@ -259,13 +265,15 @@ declare export class TypeAliasDeclaration extends Statement {
 
 // enum
 
-declare export class EnumDeclaration extends Statement {
+declare export class EnumDeclaration extends Statement {}
+
+declare export class TsEnumDeclaration extends EnumDeclaration {
   name: BindingIdentifier;
-  elements: EnumElement[];
+  elements: TsEnumElement[];
 }
 
-declare export class EnumElement extends Term {
-  parent?: EnumDeclaration;
+declare export class TsEnumElement extends Term {
+  parent?: TsEnumDeclaration;
   name: PropertyName;
   initializer?: Expression;
 }
@@ -540,13 +548,13 @@ declare export class ParenthesizedExpression extends Expression {
   inner: any;
 }
 
-declare export class AsExpression extends Expression {
+declare export class TsAsExpression extends Expression {
   expression: Expression;
-  type: TypeNode;
+  type: TsTypeNode;
 }
 
-declare export class TypeAssertion extends UnaryExpression {
-  type: TypeNode;
+declare export class TsTypeAssertion extends UnaryExpression {
+  type: TsTypeNode;
   expression: UnaryExpression;
 }
 
@@ -751,42 +759,48 @@ declare export class OperatorDeclarator extends VariableDeclarator {
 
 // type annotations
 
-declare export class TypeParameterDeclaration extends Term {
-  parent?: ClassExpression | ClassDeclaration | InterfaceDeclaration | TypeAliasDeclaration | ArrowExpression | FunctionDeclaration | SignatureTypeNode | MappedTypeNode;
-  name: any; // Identifier
-  constraint?: TypeNode;
-  default?: TypeNode;
-}
-
 declare export class TypeNode extends Term {}
+
+declare export class TypeParameterDeclaration extends Term {}
+
+// TypeScript type annotations
+
+declare export class TsTypeNode extends TypeNode {}
+
+declare export class TsTypeParameterDeclaration extends TypeParameterDeclaration {
+  parent?: ClassExpression | ClassDeclaration | InterfaceDeclaration | TsTypeAliasDeclaration | ArrowExpression | FunctionDeclaration | SignatureTsTypeNode | MappedTsTypeNode;
+  name: any; // Identifier
+  constraint?: TsTypeNode;
+  default?: TsTypeNode;
+}
 
 // Note: TypeScript also has a separate ThisTypeNode interface that is
 //       not reflected here
-declare export class KeywordTypeNode extends TypeNode {
+declare export class TsKeywordTypeNode extends TsTypeNode {
   kind: any; // 'any' | 'number' | 'object' | 'boolean' | 'string' | 'symbol' |
              // 'this' | 'void' | 'undefined' | 'null' | 'never'
 }
 
 // type FunctionOrConstructorTypeNode = FunctionTypeNode | ConstructorTypeNode
-declare export class SignatureTypeNode extends TypeNode {
-  typeParameters?: TypeParameterDeclaration[];
+declare export class SignatureTsTypeNode extends TsTypeNode {
+  typeParameters?: TsTypeParameterDeclaration[];
   params: FormalParameters;
-  type?: TypeNode;
+  type?: TsTypeNode;
 }
 // example: `(i: number, s: string) => boolean`
-declare export class FunctionTypeNode extends SignatureTypeNode {}
+declare export class FunctionTsTypeNode extends SignatureTsTypeNode {}
 // example: `new (i: number, s: string) => SomeClass`
-declare export class ConstructorNodeType extends SignatureTypeNode {}
+declare export class ConstructorTsNodeType extends SignatureTsTypeNode {}
 
 // type TypeReferenceType = TypeReferenceNode | ExpressionWithTypeArguments;
 
-declare export class TypeReferenceNode extends TypeNode {
+declare export class TsTypeReferenceNode extends TsTypeNode {
   typeName: any; // Identifier
   typeArguments?: TypeNode[];
 }
 
 // example: `SomeMapWithGenericClassValues["key"]<number, string>`
-declare export class ExpressionWithTypeArguments extends TypeNode {
+declare export class ExpressionWithTsTypeArguments extends TsTypeNode {
   parent?: HeritageClause;
   /*
    * In TypeScript, the "destination" class/interface of a heritage clause is
@@ -796,7 +810,7 @@ declare export class ExpressionWithTypeArguments extends TypeNode {
    * that permissiveness.
    */
   expression: Expression;
-  typeArguments?: TypeNode[];
+  typeArguments?: TsTypeNode[];
 }
 
 // example 1:
@@ -805,71 +819,71 @@ declare export class ExpressionWithTypeArguments extends TypeNode {
 // example 2:
 //   `this is string` in a boolean-returning class method declared as
 //   `isString(): this is string`
-declare export class TypePredicateNode extends TypeNode {
+declare export class TsTypePredicateNode extends TsTypeNode {
   parameterName: any; //  Identifier | 'this'
-  type: TypeNode;
+  type: TsTypeNode;
 }
 
 // example: `typeof someVariable`
-declare export class TypeQueryNode extends TypeNode {
+declare export class TsTypeQueryNode extends TsTypeNode {
   exprName: any; // Identifier
 }
 
 // example: `{ readonly someKey: number }`
-declare export class TypeLiteralNode extends TypeNode {
-  members: (TypeElement | IndexSignatureDeclaration)[];
+declare export class TsTypeLiteralNode extends TsTypeNode {
+  members: (TsTypeElement | IndexSignatureDeclaration)[];
 }
 
 // example: `string[]`
-declare export class ArrayTypeNode extends TypeNode {
-  elementType: TypeNode;
+declare export class ArrayTsTypeNode extends TsTypeNode {
+  elementType: TsTypeNode;
 }
 
 // example: `[string, number]`
-declare export class TupleTypeNode extends TypeNode {
-  elementTypes: TypeNode[];
+declare export class TupleTsTypeNode extends TsTypeNode {
+  elementTypes: TsTypeNode[];
 }
 
 // example: `number | string`
-declare export class UnionTypeNode extends TypeNode {
-  types: TypeNode[];
+declare export class UnionTsTypeNode extends TsTypeNode {
+  types: TsTypeNode[];
 }
 
 // example: `number & string`
-declare export class IntersectionTypeNode extends TypeNode {
-  types: TypeNode[];
+declare export class IntersectionTsTypeNode extends TsTypeNode {
+  types: TsTypeNode[];
 }
 
 // example: `(number)`
-declare export class ParenthesizedTypeNode extends TypeNode {
-  type: TypeNode;
+declare export class ParenthesizedTsTypeNode extends TsTypeNode {
+  type: TsTypeNode;
 }
 
 // example: `keyof { a: number, b: string }`
-declare export class TypeOperatorNode extends TypeNode {
+declare export class TsTypeOperatorNode extends TsTypeNode {
   operator: any; // 'keyof'
-  type: TypeNode;
+  type: TsTypeNode;
 }
 
 // example:
 //   `SomeClass[number]`
 //   where
 //   `class SomeClass { [index: number]: string }`
-declare export class IndexedAccessTypeNode extends TypeNode {
-  objectType: TypeNode;
-  indexType: TypeNode;
+declare export class IndexedAccessTsTypeNode extends TsTypeNode {
+  objectType: TsTypeNode;
+  indexType: TsTypeNode;
 }
 
 // example: `{ readonly [K in "some" | "permissible" | "keys"]: string }`
-declare export class MappedTypeNode extends TypeNode {
-  parent?: TypeAliasDeclaration;
+declare export class MappedTsTypeNode extends TsTypeNode {
+  parent?: TsTypeAliasDeclaration;
   hasReadonlyToken: any; // boolean
-  typeParameter: TypeParameterDeclaration;
+  typeParameter: TsTypeParameterDeclaration;
   hasQuestionToken: any; // boolean
-  type?: TypeNode;
+  type?: TsTypeNode;
 }
 
 // examples: `"someValue"`, `42`, `null`, `false`
-declare export class LiteralTypeNode extends TypeNode {
+declare export class LiteralTsTypeNode extends TsTypeNode {
   literal: Expression;
 }

--- a/src/term-spec.js
+++ b/src/term-spec.js
@@ -217,13 +217,14 @@ declare export class PropertySignature extends TypeElement {
 // common for classes and interfaces
 
 declare export class HeritageClause extends Term {
-  parent?: InterfaceDeclaration | ClassExpression | ClassDeclaration;
+  parent?: ClassExpression | ClassDeclaration | InterfaceDeclaration;
   types: ExpressionWithTypeArguments[];
 }
 declare export class ExtendsClause extends HeritageClause {}
 declare export class ImplementsClause extends HeritageClause {}
 
 declare export class IndexSignatureDeclaration extends Term {
+  parent?: ClassExpression | ClassDeclaration | InterfaceDeclaration | TypeLiteralNode;
   parameter: ParameterDeclaration;
   valueType: TypeNode;
 }
@@ -248,6 +249,7 @@ declare export class EnumDeclaration extends Statement {
 }
 
 declare export class EnumElement extends Term {
+  parent?: EnumDeclaration;
   name: PropertyName;
   initializer?: Expression;
 }
@@ -316,14 +318,18 @@ declare export class ExportLocalSpecifier extends Term {
 
 // property definition
 declare export class Method extends MethodDefinition {
+  parent?: ClassExpression | ClassDeclaration | ObjectExpression;
   isAsync: any;
   isGenerator: any;
   params: FormalParameters;
 }
 
-declare export class Getter extends MethodDefinition { }
+declare export class Getter extends MethodDefinition {
+  parent?: ClassExpression | ClassDeclaration | ObjectExpression;
+}
 
 declare export class Setter extends MethodDefinition {
+  parent?: ClassExpression | ClassDeclaration | ObjectExpression;
   param: ObjectBinding | ArrayBinding | BindingIdentifier | MemberExpression | BindingWithDefault;
   // param: Binding or BindingWithDefault;
 }
@@ -634,8 +640,6 @@ declare export class FormalParameters extends Term {
 }
 
 declare export class ParameterDeclaration extends Term {
-  // modifiers: ('public' | 'protected' | 'private' | 'readonly')[]
-  modifiers?: any[];
   // binding: Binding | BindingWithDefault;
   binding: ObjectBinding | ArrayBinding | BindingIdentifier | MemberExpression | BindingWithDefault;
   hasQuestionToken: any; // boolean

--- a/src/term-spec.js
+++ b/src/term-spec.js
@@ -128,13 +128,15 @@ declare export class AssignmentTargetPropertyProperty extends AssignmentTargetPr
 // class
 declare export class ClassExpression extends Expression {
   name?: BindingIdentifier;
-  super?: Expression;
+  typeParameters?: TypeParameterDeclaration[];
+  heritageClauses?: HeritageClause[];
   elements: ClassElement[];
 }
 
 declare export class ClassDeclaration extends Statement {
   name: BindingIdentifier;
-  super?: Expression;
+  typeParameters?: TypeParameterDeclaration[];
+  heritageClauses?: HeritageClause[];
   elements: ClassElement[];
 }
 
@@ -143,6 +145,22 @@ declare export class ClassElement extends Term {
   method: MethodDefinition;
 }
 
+// interface
+
+// FIXME add real definition
+declare export class InterfaceDeclaration extends Statement {}
+
+declare export class HeritageClause extends Term {
+  parent?: InterfaceDeclaration | ClassExpression | ClassDeclaration;
+  types: ExpressionWithTypeArguments[];
+}
+declare export class ExtendsClause extends HeritageClause {}
+declare export class ImplementsClause extends HeritageClause {}
+
+// type alias
+
+// FIXME add real definition
+declare export class TypeAlias extends Statement {}
 
 // modules
 declare export class Module extends Term {
@@ -219,6 +237,7 @@ declare export class Setter extends MethodDefinition {
 }
 
 declare export class DataProperty extends NamedObjectProperty {
+  hasQuestionToken: any; // boolean
   expression: Expression;
 }
 
@@ -267,13 +286,19 @@ declare export class ArrayExpression extends Expression {
 }
 
 declare export class ArrowExpression extends Expression {
-  isAsync: any;
+  isAsync: any; // boolean
+  isGenerator: any; // boolean
+  typeParameters?: TypeParameterDeclaration[];
   params: FormalParameters;
+  type?: TypeNode;
   body: FunctionBody | Expression;
 }
 declare export class ArrowExpressionE extends Expression {
-  isAsync: any;
+  isAsync: any; // boolean
+  isGenerator: any; // boolean
+  typeParameters?: TypeParameterDeclaration[];
   params: FormalParameters;
+  type?: TypeNode;
   body: Term[];
 }
 
@@ -291,6 +316,7 @@ declare export class BinaryExpression extends Expression {
 
 declare export class CallExpression extends Expression {
   callee: Expression | Super;
+  typeArguments?: TypeNode[];
   arguments: (SpreadElement | Expression)[];
 }
 
@@ -501,9 +527,17 @@ declare export class Directive extends Term {
 }
 
 declare export class FormalParameters extends Term {
-  // items: (Binding | BindingWithDefault)[];
-  items: (ObjectBinding | ArrayBinding | BindingIdentifier | MemberExpression | BindingWithDefault)[];
-  rest?: BindingIdentifier;
+  items: ParameterDeclaration[];
+  rest?: ParameterDeclaration;
+}
+
+declare export class ParameterDeclaration extends Term {
+  // modifiers: ('public' | 'protected' | 'private' | 'static' | 'readonly')[]
+  modifiers?: any[];
+  // binding: Binding | BindingWithDefault;
+  binding: ObjectBinding | ArrayBinding | BindingIdentifier | MemberExpression | BindingWithDefault;
+  hasQuestionToken: any; // boolean
+  type?: TypeNode;
 }
 
 declare export class FunctionBody extends Term {
@@ -514,15 +548,21 @@ declare export class FunctionBody extends Term {
 declare export class FunctionDeclaration extends Statement {
   name: BindingIdentifier;
   isAsync: any; // boolean
-  isGenerator: any;
+  isGenerator: any; // boolean
+  hasQuestionToken: any; // boolean
+  typeParameters?: TypeParameterDeclaration[];
   params: FormalParameters;
+  type?: TypeNode;
   body: FunctionBody;
 }
 declare export class FunctionDeclarationE extends Statement {
   name: BindingIdentifier;
   isAsync: any; // boolean
-  isGenerator: any;
+  isGenerator: any; // boolean
+  hasQuestionToken: any; // boolean
+  typeParameters?: TypeParameterDeclaration[];
   params: FormalParameters;
+  type?: TypeNode;
   body: Term[];
 }
 
@@ -566,6 +606,7 @@ declare export class VariableDeclaration extends Term {
 declare export class VariableDeclarator extends Term {
   binding: ObjectBinding | ArrayBinding | BindingIdentifier | MemberExpression;
   // binding: Binding;
+  type?: TypeNode;
   init?: Expression;
 }
 
@@ -576,11 +617,12 @@ declare export class OperatorDeclarator extends VariableDeclarator {
 
 declare export class TypeNode extends Term {}
 
-// FIXME add actual definition
-declare export class TypeParameterDeclaration extends Term {}
-
-// FIXME add actual definition
-declare export class ParameterDeclaration extends Term {}
+declare export class TypeParameterDeclaration extends Term {
+  parent?: ClassExpression | ClassDeclaration | InterfaceDeclaration | TypeAlias | ArrowExpression | FunctionDeclaration | SignatureTypeNode | MappedTypeNode;
+  name: any; // Identifier
+  constraint?: TypeNode;
+  default?: TypeNode;
+}
 
 // Note: TypeScript also has a separate ThisTypeNode interface that is
 //       not reflected here
@@ -592,7 +634,7 @@ declare export class KeywordTypeNode extends TypeNode {
 // type FunctionOrConstructorTypeNode = FunctionTypeNode | ConstructorTypeNode
 declare export class SignatureTypeNode extends TypeNode {
   typeParameters?: TypeParameterDeclaration[];
-  parameters: ParameterDeclaration[];
+  params: FormalParameters;
   type?: TypeNode;
 }
 // example: `(i: number, s: string) => boolean`
@@ -606,9 +648,6 @@ declare export class TypeReferenceNode extends TypeNode {
   typeName: any; // Identifier
   typeArguments?: TypeNode[];
 }
-
-// FIXME add actual definition
-declare export class HeritageClause extends Term {}
 
 // example: `SomeMapWithGenericClassValues["key"]<number, string>`
 declare export class ExpressionWithTypeArguments extends TypeNode {


### PR DESCRIPTION
The changes are adaptations of [TypeScript's AST nodes](https://github.com/Microsoft/TypeScript/blob/4c824505ade0740cf2848ebd862eccbabd1771db/src/compiler/types.ts). The most notable differences are:
- treatment of modifiers (public, protected, private, readonly, static, abstract) is somewhat stricter
- parameter declarations in getters and setters are restricted as in ES2017 (the TypeScript AST in principle allows for an arbitrary parameter list)
- `MethodDefinition` is a `NamedObjectProperty` but not a `ClassElement` as that would require multiple inheritance; composition is used instead
- `IndexSignatureDeclaration` is treated as a special case since in TypeScript it is the only `TypeElement` that is also a `ClassElement` - perhaps this should be handled differently
- some seemingly internal TypeScript interfaces are not included; an example of this is `MissingDeclaration`